### PR TITLE
added a definition for Lundau Length

### DIFF
--- a/hack/Lundau_Length.py
+++ b/hack/Lundau_Length.py
@@ -1,0 +1,25 @@
+#Author: John Kappel
+
+from re import M
+import numpy.np
+import astropy.units as u
+from astropy.constants.si import e
+from astropy.constants.si import k_B
+
+
+"""
+Parameters -
+    T - Temperature
+    T_E - Electron Temperature
+    n_e - Electron number density
+#################################
+
+Consants -
+    e - The electron charge 
+    k_B - Boltzmann Constant
+
+
+"""
+
+def Landau_length(T: u.T) -> u.m:
+    return e**2/ (k_B * T)


### PR DESCRIPTION
This adds a definition for Lundau Length, which is a length on one of the  Plasma parameters: https://en.wikipedia.org/wiki/Plasma_parameters, suggested by Will DeShazer.